### PR TITLE
Add str_first_char function

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2446,6 +2446,9 @@ function str_starts_with(string $haystack, string $needle): bool {}
 /** @compile-time-eval */
 function str_ends_with(string $haystack, string $needle): bool {}
 
+/** @compile-time-eval */
+function str_first_char(string $string): string {}
+
 /**
  * @compile-time-eval
  * @refcount 1

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: deb4ea96dd130d8a0174678095c30a61e118bd60 */
+ * Stub hash: 6079be98e96354abb8558100e5a11dc2059b7806 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -921,6 +921,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_str_starts_with arginfo_str_contains
 
 #define arginfo_str_ends_with arginfo_str_contains
+
+#define arginfo_str_first_char arginfo_base64_encode
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_chunk_split, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
@@ -2547,6 +2549,7 @@ ZEND_FUNCTION(strrchr);
 ZEND_FUNCTION(str_contains);
 ZEND_FUNCTION(str_starts_with);
 ZEND_FUNCTION(str_ends_with);
+ZEND_FUNCTION(str_first_char);
 ZEND_FUNCTION(chunk_split);
 ZEND_FUNCTION(substr);
 ZEND_FUNCTION(substr_replace);
@@ -3148,6 +3151,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY("str_contains", zif_str_contains, arginfo_str_contains, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_str_contains, NULL)
 	ZEND_RAW_FENTRY("str_starts_with", zif_str_starts_with, arginfo_str_starts_with, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_str_starts_with, NULL)
 	ZEND_RAW_FENTRY("str_ends_with", zif_str_ends_with, arginfo_str_ends_with, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
+	ZEND_RAW_FENTRY("str_first_char", zif_str_first_char, arginfo_str_first_char, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("chunk_split", zif_chunk_split, arginfo_chunk_split, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_RAW_FENTRY("substr", zif_substr, arginfo_substr, ZEND_ACC_COMPILE_TIME_EVAL, frameless_function_infos_substr, NULL)
 	ZEND_RAW_FENTRY("substr_replace", zif_substr_replace, arginfo_substr_replace, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1885,6 +1885,23 @@ PHP_FUNCTION(str_ends_with)
 }
 /* }}} */
 
+/* {{{ Returns the first character of a string */
+PHP_FUNCTION(str_first_char)
+{
+	zend_string *str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (ZSTR_LEN(str) == 0) {
+		RETURN_EMPTY_STRING();
+	}
+
+	RETURN_STRINGL(ZSTR_VAL(str), 1);
+}
+/* }}} */
+
 static inline void _zend_strpos(zval *return_value, zend_string *haystack, zend_string *needle, zend_long offset)
 {
 	const char *found = NULL;

--- a/ext/standard/tests/strings/str_first_char.phpt
+++ b/ext/standard/tests/strings/str_first_char.phpt
@@ -1,0 +1,20 @@
+--TEST--
+str_first_char() function
+--SKIPIF--
+<?php
+if (!function_exists('str_first_char')) {
+    die('skip str_first_char() is not available');
+}
+?>
+--FILE--
+<?php
+var_dump(str_first_char("hello"));
+var_dump(str_first_char("123"));
+var_dump(str_first_char(""));
+var_dump(str_first_char(" a b c "));
+?>
+--EXPECT--
+string(1) "h"
+string(1) "1"
+string(0) ""
+string(1) " "


### PR DESCRIPTION
This commit introduces a new function, `str_first_char`, which returns the first character of a given string.

The function is implemented in `ext/standard/string.c` and its stub is added to `ext/standard/basic_functions.stub.php`.

A test case is included to verify the new function's behavior.