### PR TITLE
Add test for zend_version()

### DIFF
--- a/ext/standard/tests/general_functions/zend_version.phpt
+++ b/ext/standard/tests/general_functions/zend_version.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Test zend_version() function
+--FILE--
+<?php
+var_dump(zend_version());
+?>
+--EXPECTREGEX--
+string\(\d+\) "\d\.\d+\.\d+.*"


### PR DESCRIPTION
This commit adds a test for the `zend_version()` function, which was previously untested according to the `find_tested.php` script.