### PR TITLE
feat(gd): Optimize gdImageSmooth with SIMD

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -220,12 +220,17 @@ dnl
 
 if test "$PHP_GD" != "no"; then
   if test "$PHP_EXTERNAL_GD" = "no"; then
+    AX_CHECK_COMPILE_FLAG([-msse2], [CFLAGS="$CFLAGS -msse2"])
+    AX_CHECK_COMPILE_FLAG([-mavx], [CFLAGS="$CFLAGS -mavx"])
+
     extra_sources=m4_normalize(["
       libgd/gd_avif.c
       libgd/gd_bmp.c
       libgd/gd_color_match.c
       libgd/gd_crop.c
       libgd/gd_filter.c
+      libgd/gd_filter_simd.c
+      libgd/gd_simd.c
       libgd/gd_gd.c
       libgd/gd_gd2.c
       libgd/gd_gif_in.c

--- a/ext/gd/libgd/gd_filter.c
+++ b/ext/gd/libgd/gd_filter.c
@@ -1,4 +1,6 @@
 #include "gd.h"
+#include "gd_simd.h"
+#include "gd_filter_simd.h"
 
 #include "gd_intern.h"
 
@@ -612,6 +614,18 @@ int gdImageMeanRemoval(gdImagePtr im)
 
 int gdImageSmooth(gdImagePtr im, float weight)
 {
+	if (gd_have_avx()) {
+		if (gdImageSmooth_avx(im, weight)) {
+			return 1;
+		}
+	}
+
+	if (gd_have_sse2()) {
+		if (gdImageSmooth_sse2(im, weight)) {
+			return 1;
+		}
+	}
+
 	float filter[3][3] =	{{1.0,1.0,1.0},
 				{1.0,0.0,1.0},
 				{1.0,1.0,1.0}};

--- a/ext/gd/libgd/gd_filter_simd.c
+++ b/ext/gd/libgd/gd_filter_simd.c
@@ -1,0 +1,126 @@
+#include "gd.h"
+#include "gd_intern.h"
+#include "gd_filter_simd.h"
+
+#if (defined(__GNUC__) || defined(__clang__)) && (defined(__x86_64__) || defined(__i386__))
+#include <emmintrin.h>
+
+static void gdImageSmooth_sse2_row(gdImagePtr im, gdImagePtr srcback, int y, float weight)
+{
+	int x;
+	const int sx = im->sx;
+	const float div = weight + 8.0f;
+	const __m128 div_ps = _mm_set1_ps(div);
+	const __m128 weight_ps = _mm_set1_ps(weight - 1.0f);
+
+	for (x = 0; x < sx - 3; x+=4) {
+		int i, j;
+		__m128 sum_r = _mm_setzero_ps();
+		__m128 sum_g = _mm_setzero_ps();
+		__m128 sum_b = _mm_setzero_ps();
+		__m128i center_pixels = _mm_loadu_si128((__m128i*)&srcback->tpixels[y][x]);
+
+		for (j = -1; j <= 1; j++) {
+			for (i = -1; i <= 1; i++) {
+				__m128i pixels = _mm_loadu_si128((__m128i*)&srcback->tpixels[y+j][x+i]);
+				__m128i r = _mm_and_si128(_mm_srli_epi32(pixels, 16), _mm_set1_epi32(0xff));
+				__m128i g = _mm_and_si128(_mm_srli_epi32(pixels, 8), _mm_set1_epi32(0xff));
+				__m128i b = _mm_and_si128(pixels, _mm_set1_epi32(0xff));
+
+				sum_r = _mm_add_ps(sum_r, _mm_cvtepi32_ps(r));
+				sum_g = _mm_add_ps(sum_g, _mm_cvtepi32_ps(g));
+				sum_b = _mm_add_ps(sum_b, _mm_cvtepi32_ps(b));
+			}
+		}
+
+		__m128i center_r = _mm_and_si128(_mm_srli_epi32(center_pixels, 16), _mm_set1_epi32(0xff));
+		__m128i center_g = _mm_and_si128(_mm_srli_epi32(center_pixels, 8), _mm_set1_epi32(0xff));
+		__m128i center_b = _mm_and_si128(center_pixels, _mm_set1_epi32(0xff));
+
+		sum_r = _mm_add_ps(sum_r, _mm_mul_ps(_mm_cvtepi32_ps(center_r), weight_ps));
+		sum_g = _mm_add_ps(sum_g, _mm_mul_ps(_mm_cvtepi32_ps(center_g), weight_ps));
+		sum_b = _mm_add_ps(sum_b, _mm_mul_ps(_mm_cvtepi32_ps(center_b), weight_ps));
+
+		sum_r = _mm_div_ps(sum_r, div_ps);
+		sum_g = _mm_div_ps(sum_g, div_ps);
+		sum_b = _mm_div_ps(sum_b, div_ps);
+
+		sum_r = _mm_max_ps(_mm_setzero_ps(), _mm_min_ps(sum_r, _mm_set1_ps(255.0f)));
+		sum_g = _mm_max_ps(_mm_setzero_ps(), _mm_min_ps(sum_g, _mm_set1_ps(255.0f)));
+		sum_b = _mm_max_ps(_mm_setzero_ps(), _mm_min_ps(sum_b, _mm_set1_ps(255.0f)));
+
+		__m128i r_int = _mm_cvtps_epi32(sum_r);
+		__m128i g_int = _mm_cvtps_epi32(sum_g);
+		__m128i b_int = _mm_cvtps_epi32(sum_b);
+
+		__m128i alpha = _mm_and_si128(_mm_srli_epi32(center_pixels, 24), _mm_set1_epi32(0xff));
+		r_int = _mm_slli_epi32(r_int, 16);
+		g_int = _mm_slli_epi32(g_int, 8);
+		alpha = _mm_slli_epi32(alpha, 24);
+
+		__m128i final_pixels = _mm_or_si128(_mm_or_si128(r_int, g_int), _mm_or_si128(b_int, alpha));
+		_mm_storeu_si128((__m128i*)&im->tpixels[y][x], final_pixels);
+	}
+
+	for (; x < sx; x++) {
+		float new_r = 0.0f, new_g = 0.0f, new_b = 0.0f;
+		int i, j;
+
+		for (j = -1; j <= 1; j++) {
+			for (i = -1; i <= 1; i++) {
+				int pxl = im->tpixels[y+j][x+i];
+				new_r += gdTrueColorGetRed(pxl);
+				new_g += gdTrueColorGetGreen(pxl);
+				new_b += gdTrueColorGetBlue(pxl);
+			}
+		}
+
+		int pxl = im->tpixels[y][x];
+		new_r += gdTrueColorGetRed(pxl) * (weight - 1.0f);
+		new_g += gdTrueColorGetGreen(pxl) * (weight - 1.0f);
+		new_b += gdTrueColorGetBlue(pxl) * (weight - 1.0f);
+
+		new_r /= div;
+		new_g /= div;
+		new_b /= div;
+
+		new_r = new_r < 0 ? 0 : (new_r > 255 ? 255 : new_r);
+		new_g = new_g < 0 ? 0 : (new_g > 255 ? 255 : new_g);
+		new_b = new_b < 0 ? 0 : (new_b > 255 ? 255 : new_b);
+
+		im->tpixels[y][x] = gdTrueColorAlpha((int)new_r, (int)new_g, (int)new_b, gdTrueColorGetAlpha(pxl));
+	}
+}
+
+
+int gdImageSmooth_sse2(gdImagePtr im, float weight)
+{
+	if (!im->trueColor) {
+		return 0;
+	}
+
+	gdImagePtr srcback = gdImageCreateTrueColor(im->sx, im->sy);
+	if (!srcback) {
+		return 0;
+	}
+	gdImageCopy(srcback, im, 0, 0, 0, 0, im->sx, im->sy);
+
+	for (int y = 1; y < im->sy - 1; y++) {
+		gdImageSmooth_sse2_row(im, srcback, y, weight);
+	}
+
+	gdImageDestroy(srcback);
+	return 1;
+}
+#else
+int gdImageSmooth_sse2(gdImagePtr im, float weight)
+{
+	return 0;
+}
+#endif
+
+int gdImageSmooth_avx(gdImagePtr im, float weight)
+{
+	/* TODO: Add AVX implementation */
+	return 0;
+}

--- a/ext/gd/libgd/gd_filter_simd.h
+++ b/ext/gd/libgd/gd_filter_simd.h
@@ -1,0 +1,9 @@
+#ifndef GD_FILTER_SIMD_H
+#define GD_FILTER_SIMD_H
+
+#include "gd.h"
+
+int gdImageSmooth_avx(gdImagePtr im, float weight);
+int gdImageSmooth_sse2(gdImagePtr im, float weight);
+
+#endif /* GD_FILTER_SIMD_H */

--- a/ext/gd/libgd/gd_simd.c
+++ b/ext/gd/libgd/gd_simd.c
@@ -1,0 +1,55 @@
+#include "gd_simd.h"
+
+#if defined(__GNUC__) || defined(__clang__)
+#include <cpuid.h>
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+static int gd_simd_features = -1;
+
+#define GD_SIMD_AVX (1 << 0)
+#define GD_SIMD_SSE2 (1 << 1)
+
+static void gd_check_simd_features(void)
+{
+	gd_simd_features = 0;
+
+#if (defined(__GNUC__) || defined(__clang__)) && (defined(__x86_64__) || defined(__i386__))
+	unsigned int eax, ebx, ecx, edx;
+
+	if (__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+		if (edx & (1 << 26)) {
+			gd_simd_features |= GD_SIMD_SSE2;
+		}
+		if (ecx & (1 << 28)) {
+			gd_simd_features |= GD_SIMD_AVX;
+		}
+	}
+#elif defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_IX86))
+	int info[4];
+	__cpuid(info, 1);
+	if (info[3] & (1 << 26)) {
+		gd_simd_features |= GD_SIMD_SSE2;
+	}
+	if (info[2] & (1 << 28)) {
+		gd_simd_features |= GD_SIMD_AVX;
+	}
+#endif
+}
+
+int gd_have_avx(void)
+{
+	if (gd_simd_features < 0) {
+		gd_check_simd_features();
+	}
+	return (gd_simd_features & GD_SIMD_AVX) != 0;
+}
+
+int gd_have_sse2(void)
+{
+	if (gd_simd_features < 0) {
+		gd_check_simd_features();
+	}
+	return (gd_simd_features & GD_SIMD_SSE2) != 0;
+}

--- a/ext/gd/libgd/gd_simd.h
+++ b/ext/gd/libgd/gd_simd.h
@@ -1,0 +1,9 @@
+#ifndef GD_SIMD_H
+#define GD_SIMD_H
+
+#include "gd.h"
+
+int gd_have_avx(void);
+int gd_have_sse2(void);
+
+#endif /* GD_SIMD_H */


### PR DESCRIPTION
This commit introduces SIMD optimizations for the `gdImageSmooth` function in the GD extension.

The main changes are:
- A new file `ext/gd/libgd/gd_simd.c` with runtime detection for SSE2 and AVX.
- A new file `ext/gd/libgd/gd_filter_simd.c` with an SSE2 implementation of `gdImageSmooth`.
- The `gdImageSmooth` function in `ext/gd/libgd/gd_filter.c` is modified to call the SIMD version if available, otherwise it falls back to the original implementation.
- The build system is updated to include the new files and the necessary compiler flags.

This optimization should improve the performance of the `gdImageSmooth` function on x86 platforms that support SSE2 or AVX.