### PR TITLE
feat: Implement the repeat loop from Kotlin in PHP

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -215,6 +215,38 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 /* }}} */
 #endif
 
+/* {{{ Repeats a function N times */
+PHP_FUNCTION(repeat)
+{
+	zend_long times;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fci_cache;
+	zval retval;
+	zval params[1];
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(times)
+		Z_PARAM_FUNC(fci, fci_cache)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (times <= 0) {
+		return;
+	}
+
+	fci.retval = &retval;
+	fci.param_count = 1;
+	fci.params = params;
+
+	for (zend_long i = 0; i < times; i++) {
+		ZVAL_LONG(&params[0], i);
+		if (zend_call_function(&fci, &fci_cache) == FAILURE) {
+			return;
+		}
+		zval_ptr_dtor(&retval);
+	}
+}
+/* }}} */
+
 static void basic_globals_ctor(php_basic_globals *basic_globals_p) /* {{{ */
 {
 	memset(basic_globals_p, 0, sizeof(php_basic_globals));

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2580,6 +2580,8 @@ function str_getcsv(string $string, string $separator = ",", string $enclosure =
 /** @refcount 1 */
 function str_repeat(string $string, int $times): string {}
 
+function repeat(int $times, callable $action): void {}
+
 /**
  * @return array<int, int>|string
  * @compile-time-eval

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6079be98e96354abb8558100e5a11dc2059b7806 */
+ * Stub hash: fc31f5f802176c8db73428661496dc3b7e4fe98c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1032,6 +1032,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_str_repeat, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, times, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_repeat, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, times, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, action, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_count_chars, 0, 1, MAY_BE_ARRAY|MAY_BE_STRING)
@@ -2575,6 +2580,7 @@ ZEND_FUNCTION(setlocale);
 ZEND_FUNCTION(parse_str);
 ZEND_FUNCTION(str_getcsv);
 ZEND_FUNCTION(str_repeat);
+ZEND_FUNCTION(repeat);
 ZEND_FUNCTION(count_chars);
 ZEND_FUNCTION(strnatcmp);
 ZEND_FUNCTION(localeconv);
@@ -3177,6 +3183,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(parse_str, arginfo_parse_str)
 	ZEND_FE(str_getcsv, arginfo_str_getcsv)
 	ZEND_FE(str_repeat, arginfo_str_repeat)
+	ZEND_FE(repeat, arginfo_repeat)
 	ZEND_RAW_FENTRY("count_chars", zif_count_chars, arginfo_count_chars, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 	ZEND_FE(strnatcmp, arginfo_strnatcmp)
 	ZEND_FE(localeconv, arginfo_localeconv)

--- a/ext/standard/tests/repeat.phpt
+++ b/ext/standard/tests/repeat.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test repeat() function
+--FILE--
+<?php
+echo "Test with positive repetitions:\n";
+$a = 0;
+repeat(5, function($i) use (&$a) {
+    echo "iteration: $i\n";
+    $a += $i;
+});
+echo "Result: $a\n";
+
+echo "\nTest with zero repetitions:\n";
+repeat(0, function($i) {
+    echo "This should not be printed.\n";
+});
+echo "Completed zero repetitions.\n";
+
+echo "\nTest with negative repetitions:\n";
+repeat(-5, function($i) {
+    echo "This should not be printed.\n";
+});
+echo "Completed negative repetitions.\n";
+?>
+--EXPECT--
+Test with positive repetitions:
+iteration: 0
+iteration: 1
+iteration: 2
+iteration: 3
+iteration: 4
+Result: 10
+
+Test with zero repetitions:
+Completed zero repetitions.
+
+Test with negative repetitions:
+Completed negative repetitions.


### PR DESCRIPTION
This commit introduces a new `repeat` function in PHP, which is inspired by the `repeat` loop in Kotlin. The function takes an integer `times` and a `callable` `action` as arguments. It executes the `action` `times` number of times, passing the current iteration index (from 0 to `times - 1`) to the `action`.

The implementation includes:
- The C code for the `repeat` function in `ext/standard/basic_functions.c`.
- The function signature in `ext/standard/basic_functions.stub.php`.
- A test file in `ext/standard/tests/repeat.phpt` to ensure the function works as expected.