### PR TITLE
Optimize ksort for integer-keyed arrays

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -3379,6 +3379,23 @@ convert:
 	}
 }
 
+ZEND_API bool ZEND_FASTCALL zend_array_is_int_keyed(const zend_array *array)
+{
+	zend_string *key;
+
+	if (HT_IS_PACKED(array)) {
+		return 1;
+	}
+
+	ZEND_HASH_MAP_FOREACH_STR_KEY(array, key) {
+		if (key) {
+			return 0;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return 1;
+}
+
 /* Takes a "proptable" hashtable (contains only string keys) and converts it to
  * a "symtable" (contains integer and non-numeric string keys).
  * If the proptable didn't need duplicating, its refcount is incremented.

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -1523,6 +1523,8 @@ static zend_always_inline void *zend_hash_get_current_data_ptr_ex(const HashTabl
 	_h = _idx; \
 	_ptr = Z_PTR_P(_z);
 
+ZEND_API bool ZEND_FASTCALL zend_array_is_int_keyed(const zend_array *array);
+
 /* The following macros are useful to insert a sequence of new elements
  * of packed array. They may be used instead of series of
  * zend_hash_next_index_insert_new()

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -214,6 +214,12 @@ static zend_always_inline int php_array_key_compare_string_unstable_i(Bucket *f,
 }
 /* }}} */
 
+static zend_always_inline int php_array_key_compare_integer_unstable_i(Bucket *f, Bucket *s) /* {{{ */
+{
+	return (zend_long)f->h > (zend_long)s->h ? 1 : -1;
+}
+/* }}} */
+
 static int php_array_key_compare_string_natural_general(Bucket *f, Bucket *s, int fold_case) /* {{{ */
 {
 	const char *s1, *s2;
@@ -363,6 +369,7 @@ DEFINE_SORT_VARIANTS(key_compare);
 DEFINE_SORT_VARIANTS(key_compare_numeric);
 DEFINE_SORT_VARIANTS(key_compare_string_case);
 DEFINE_SORT_VARIANTS(key_compare_string);
+DEFINE_SORT_VARIANTS(key_compare_integer);
 DEFINE_SORT_VARIANTS(key_compare_string_locale);
 DEFINE_SORT_VARIANTS(data_compare);
 DEFINE_SORT_VARIANTS(data_compare_numeric);
@@ -380,6 +387,14 @@ static bucket_compare_func_t php_get_key_compare_func(zend_long sort_type, int r
 				return php_array_reverse_key_compare_numeric;
 			} else {
 				return php_array_key_compare_numeric;
+			}
+			break;
+
+		case PHP_SORT_INTEGER:
+			if (reverse) {
+				return php_array_reverse_key_compare_integer;
+			} else {
+				return php_array_key_compare_integer;
 			}
 			break;
 
@@ -597,6 +612,12 @@ PHP_FUNCTION(ksort)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(sort_type)
 	ZEND_PARSE_PARAMETERS_END();
+
+	if ((sort_type == PHP_SORT_REGULAR || sort_type == PHP_SORT_NUMERIC) &&
+		zend_array_is_int_keyed(Z_ARRVAL_P(array))
+	) {
+		sort_type = PHP_SORT_INTEGER;
+	}
 
 	cmp = php_get_key_compare_func(sort_type, 0);
 

--- a/ext/standard/php_array.h
+++ b/ext/standard/php_array.h
@@ -54,6 +54,7 @@ PHPAPI bool php_array_pick_keys(php_random_algo_with_state engine, zval *input, 
 #define PHP_SORT_ASC                4
 #define PHP_SORT_LOCALE_STRING      5
 #define PHP_SORT_NATURAL            6
+#define PHP_SORT_INTEGER            7
 #define PHP_SORT_FLAG_CASE          8
 
 #define PHP_COUNT_NORMAL      0

--- a/ext/standard/tests/array/sort/ksort_integer_keys.phpt
+++ b/ext/standard/tests/array/sort/ksort_integer_keys.phpt
@@ -1,0 +1,59 @@
+--TEST--
+ksort() with integer keys
+--FILE--
+<?php
+$array = [2 => 'two', 1 => 'one', 0 => 'zero'];
+ksort($array);
+var_dump($array);
+
+$array = [10 => 'ten', 5 => 'five', 15 => 'fifteen'];
+ksort($array);
+var_dump($array);
+
+$array = [];
+ksort($array);
+var_dump($array);
+
+$array = [0 => 'a', 1 => 'b', 2 => 'c'];
+ksort($array);
+var_dump($array);
+
+$array = [PHP_INT_MAX => 'max', 0 => 'zero', PHP_INT_MIN => 'min'];
+ksort($array);
+var_dump($array);
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(4) "zero"
+  [1]=>
+  string(3) "one"
+  [2]=>
+  string(3) "two"
+}
+array(3) {
+  [5]=>
+  string(4) "five"
+  [10]=>
+  string(3) "ten"
+  [15]=>
+  string(7) "fifteen"
+}
+array(0) {
+}
+array(3) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+  [2]=>
+  string(1) "c"
+}
+array(3) {
+  [-9223372036854775808]=>
+  string(3) "min"
+  [0]=>
+  string(4) "zero"
+  [9223372036854775807]=>
+  string(3) "max"
+}


### PR DESCRIPTION
This commit introduces an optimization for the ksort() function for arrays that contain only integer keys.

A new helper function, `zend_array_is_int_keyed`, is introduced to check if an array has only integer keys. If this is the case, and the sort flag is `PHP_SORT_REGULAR` or `PHP_SORT_NUMERIC`, a new specialized comparison function, `php_array_key_compare_integer`, is used. This avoids unnecessary type conversions and comparisons, leading to a performance improvement.

A new test file is added to verify the correctness of the implementation.