### PR TITLE
feat: Add cat command function

### DIFF
--- a/ext/cat/cat.c
+++ b/ext/cat/cat.c
@@ -1,0 +1,56 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_cat.h"
+#include "ext/standard/file.h"
+#include "cat_arginfo.h"
+
+PHP_FUNCTION(cat)
+{
+    char *filename;
+    size_t filename_len;
+    FILE *fp;
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t read;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &filename, &filename_len) == FAILURE) {
+        return;
+    }
+
+    fp = fopen(filename, "r");
+    if (!fp) {
+        php_error_docref(NULL, E_WARNING, "Failed to open file: %s", filename);
+        RETURN_FALSE;
+    }
+
+    array_init(return_value);
+
+    while ((read = getline(&line, &len, fp)) != -1) {
+        add_next_index_stringl(return_value, line, read);
+    }
+
+    fclose(fp);
+    if (line) {
+        free(line);
+    }
+}
+
+zend_module_entry cat_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "cat",
+    ext_functions,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    "1.0.0",
+    STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_CAT
+ZEND_GET_MODULE(cat)
+#endif

--- a/ext/cat/cat.stub.php
+++ b/ext/cat/cat.stub.php
@@ -1,0 +1,5 @@
+<?php
+
+/** @generate-function-entries */
+
+function cat(string $filename): array|false {}

--- a/ext/cat/cat_arginfo.h
+++ b/ext/cat/cat_arginfo.h
@@ -1,0 +1,13 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 311d1049e32af017b44e260a00f13830714b1e96 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_cat, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_FUNCTION(cat);
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(cat, arginfo_cat)
+	ZEND_FE_END
+};

--- a/ext/cat/config.m4
+++ b/ext/cat/config.m4
@@ -1,0 +1,8 @@
+PHP_ARG_WITH([cat],
+  [for cat support],
+  [AS_HELP_STRING([--with-cat],
+    [Include cat support])])
+
+if test "$PHP_CAT" != "no"; then
+  PHP_NEW_EXTENSION(cat, cat.c, $ext_shared)
+fi

--- a/ext/cat/php_cat.h
+++ b/ext/cat/php_cat.h
@@ -1,0 +1,7 @@
+#ifndef PHP_CAT_H
+#define PHP_CAT_H
+
+extern zend_module_entry cat_module_entry;
+#define phpext_cat_ptr &cat_module_entry
+
+#endif


### PR DESCRIPTION
This commit introduces a new PHP extension that provides a `cat` function. The `cat` function reads a file and returns its content as an array of lines. This is similar to the `cat` command in Unix-like operating systems.

The extension is self-contained and can be enabled with the `--with-cat` configure option.

The implementation uses `getline` to read lines of arbitrary length, avoiding buffer overflows.