### PR TITLE
Implement php_grep function

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -40,6 +40,7 @@
 #include "ext/standard/php_dns.h"
 #include "ext/standard/php_uuencode.h"
 #include "ext/standard/crc32_x86.h"
+#include "php_grep.h"
 
 #ifdef PHP_WIN32
 #include "win32/php_win32_globals.h"

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2071,6 +2071,8 @@ function is_uploaded_file(string $filename): bool {}
 
 function move_uploaded_file(string $from, string $to): bool {}
 
+function php_grep(string $pattern, string $filename): array|false {}
+
 /**
  * @return array<int|string, bool|int|float|string|array|null>|false
  * @refcount 1

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fc31f5f802176c8db73428661496dc3b7e4fe98c */
+ * Stub hash: 852785b70a4f1036e61f96b5138d27d27d8f6e7a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -583,6 +583,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_move_uploaded_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, from, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, to, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_php_grep, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_parse_ini_file, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
@@ -2459,6 +2464,7 @@ ZEND_FUNCTION(register_tick_function);
 ZEND_FUNCTION(unregister_tick_function);
 ZEND_FUNCTION(is_uploaded_file);
 ZEND_FUNCTION(move_uploaded_file);
+ZEND_FUNCTION(php_grep);
 ZEND_FUNCTION(parse_ini_file);
 ZEND_FUNCTION(parse_ini_string);
 #if ZEND_DEBUG
@@ -3057,6 +3063,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(unregister_tick_function, arginfo_unregister_tick_function)
 	ZEND_FE(is_uploaded_file, arginfo_is_uploaded_file)
 	ZEND_FE(move_uploaded_file, arginfo_move_uploaded_file)
+	ZEND_FE(php_grep, arginfo_php_grep)
 	ZEND_FE(parse_ini_file, arginfo_parse_ini_file)
 	ZEND_RAW_FENTRY("parse_ini_string", zif_parse_ini_string, arginfo_parse_ini_string, ZEND_ACC_COMPILE_TIME_EVAL, NULL, NULL)
 #if ZEND_DEBUG

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -388,6 +388,7 @@ dnl Setup extension sources
 dnl
 PHP_NEW_EXTENSION([standard], m4_normalize([
     array.c
+    grep.c
     assert.c
     base64.c
     basic_functions.c

--- a/ext/standard/grep.c
+++ b/ext/standard/grep.c
@@ -1,0 +1,80 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Jules <jules@upwork.com>                                     |
+   +----------------------------------------------------------------------+
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_ini.h"
+#include "ext/standard/info.h"
+#include "php_grep.h"
+#include "ext/pcre/php_pcre.h"
+#include "php_streams.h"
+
+PHP_FUNCTION(php_grep)
+{
+    char *pattern, *filename;
+    size_t pattern_len, filename_len;
+    php_stream *stream;
+    char *line = NULL;
+    size_t line_len;
+    pcre2_code *re;
+    PCRE2_UCHAR *pcre_pattern;
+    int errorcode;
+    PCRE2_SIZE erroroffset;
+    pcre2_match_data *match_data;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(pattern, pattern_len)
+        Z_PARAM_STRING(filename, filename_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    pcre_pattern = (PCRE2_UCHAR *)pattern;
+    re = pcre2_compile(pcre_pattern, pattern_len, 0, &errorcode, &erroroffset, NULL);
+
+    if (re == NULL) {
+        PCRE2_UCHAR buffer[256];
+        pcre2_get_error_message(errorcode, buffer, sizeof(buffer));
+        php_error_docref(NULL, E_WARNING, "PCRE compilation failed: %s at offset %d", buffer, (int)erroroffset);
+        RETURN_FALSE;
+    }
+
+    stream = php_stream_open_wrapper(filename, "r", 0, NULL);
+    if (stream == NULL) {
+        pcre2_code_free(re);
+        php_error_docref(NULL, E_WARNING, "Failed to open file: %s", filename);
+        RETURN_FALSE;
+    }
+
+    array_init(return_value);
+
+    match_data = pcre2_match_data_create_from_pattern(re, NULL);
+    while ((line = _php_stream_get_line(stream, NULL, 0, &line_len)) != NULL) {
+        int rc;
+
+        rc = pcre2_match(re, (PCRE2_UCHAR *)line, line_len, 0, 0, match_data, NULL);
+
+        if (rc >= 0) {
+            add_next_index_stringl(return_value, line, line_len);
+        }
+        efree(line);
+    }
+
+    pcre2_match_data_free(match_data);
+    php_stream_close(stream);
+    pcre2_code_free(re);
+}

--- a/ext/standard/php_grep.h
+++ b/ext/standard/php_grep.h
@@ -1,0 +1,22 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Jules <jules@upwork.com>                                     |
+   +----------------------------------------------------------------------+
+ */
+
+#ifndef PHP_GREP_H
+#define PHP_GREP_H
+
+PHP_FUNCTION(php_grep);
+
+#endif /* PHP_GREP_H */

--- a/ext/standard/tests/grep.phpt
+++ b/ext/standard/tests/grep.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test php_grep() function
+--FILE--
+<?php
+$file = tempnam(sys_get_temp_dir(), 'grep_test');
+file_put_contents($file, "hello world\nthis is a test\nhello again\n");
+$result = php_grep('hello', $file);
+var_dump($result);
+unlink($file);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(12) "hello world
+"
+  [1]=>
+  string(12) "hello again
+"
+}


### PR DESCRIPTION
This commit introduces a new function, `php_grep`, which emulates the functionality of the `grep` command.

The `php_grep` function takes a PCRE pattern and a filename as input, and returns an array of all lines in the file that match the given pattern.

The implementation uses PHP's stream API to read the file, which allows it to handle lines of any length efficiently. It also includes error handling for PCRE compilation and file opening, and provides informative warnings to the user.