### PR TITLE
feat: Add function to list directory contents

### DIFF
--- a/jules/ls.php
+++ b/jules/ls.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Lists files and directories inside the specified directory.
+ *
+ * @param string $directory The directory to list. Defaults to the current directory.
+ * @return string[] An array of file and directory names.
+ */
+function ls(string $directory = '.'): array
+{
+    // Return scandir result directly, or an empty array if it fails.
+    return scandir($directory) ?: [];
+}


### PR DESCRIPTION
This commit introduces a new function that mimics the behavior of the `ls` command.

The function is defined in `jules/ls.php` and takes an optional directory path as an argument. It returns an array of strings containing the names of the files and directories in the specified path.

This function provides a simple way to list directory contents within PHP scripts.