### PR TITLE
Feature: Add 'A' mode to php_uname to return an array

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -648,7 +648,7 @@ static void php_get_windows_cpu(char *buf, size_t bufsize)
 #endif
 
 static inline bool php_is_valid_uname_mode(char mode) {
-	return mode == 'a' || mode == 'm' || mode == 'n' || mode == 'r' || mode == 's' || mode == 'v';
+	return mode == 'a' || mode == 'm' || mode == 'n' || mode == 'r' || mode == 's' || mode == 'v' || mode == 'A';
 }
 
 /* {{{ php_get_uname */
@@ -1323,11 +1323,20 @@ PHP_FUNCTION(php_uname)
 
 	char mode = *mode_str;
 	if (!php_is_valid_uname_mode(mode)) {
-		zend_argument_value_error(1, "must be one of \"a\", \"m\", \"n\", \"r\", \"s\", or \"v\"");
+		zend_argument_value_error(1, "must be one of \"a\", \"m\", \"n\", \"r\", \"s\", \"v\", or \"A\"");
 		RETURN_THROWS();
 	}
 
-	RETURN_STR(php_get_uname(mode));
+	if (mode == 'A') {
+		array_init(return_value);
+		add_assoc_str(return_value, "sysname", php_get_uname('s'));
+		add_assoc_str(return_value, "nodename", php_get_uname('n'));
+		add_assoc_str(return_value, "release", php_get_uname('r'));
+		add_assoc_str(return_value, "version", php_get_uname('v'));
+		add_assoc_str(return_value, "machine", php_get_uname('m'));
+	} else {
+		RETURN_STR(php_get_uname(mode));
+	}
 }
 
 /* }}} */

--- a/ext/standard/tests/general_functions/php_uname_array.phpt
+++ b/ext/standard/tests/general_functions/php_uname_array.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test php_uname() function - array return
+--SKIPIF--
+<?php if (!function_exists("php_uname")) print "skip"; ?>
+--FILE--
+<?php
+echo "*** Testing php_uname() - array return\n";
+$uname_array = php_uname('A');
+var_dump(is_array($uname_array));
+var_dump(array_key_exists('sysname', $uname_array));
+var_dump(array_key_exists('nodename', $uname_array));
+var_dump(array_key_exists('release', $uname_array));
+var_dump(array_key_exists('version', $uname_array));
+var_dump(array_key_exists('machine', $uname_array));
+?>
+--EXPECT--
+*** Testing php_uname() - array return
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/standard/tests/general_functions/php_uname_error.phpt
+++ b/ext/standard/tests/general_functions/php_uname_error.phpt
@@ -23,4 +23,4 @@ try {
 --EXPECT--
 ValueError: php_uname(): Argument #1 ($mode) must be a single character
 ValueError: php_uname(): Argument #1 ($mode) must be a single character
-ValueError: php_uname(): Argument #1 ($mode) must be one of "a", "m", "n", "r", "s", or "v"
+ValueError: php_uname(): Argument #1 ($mode) must be one of "a", "m", "n", "r", "s", "v", or "A"


### PR DESCRIPTION
This commit introduces a new mode 'A' to the `php_uname()` function. When called with 'A' as the mode, the function now returns an associative array containing the system information, with keys for sysname, nodename, release, version, and machine.

This provides a more structured way to access system information compared to the concatenated string returned by the 'a' mode.

The implementation reuses the existing `php_get_uname()` helper function to ensure consistency and cross-platform compatibility.

A new test case has been added to verify the functionality of the new 'A' mode, and the existing error-handling test has been updated to include the new mode in its expected output.