### PR TITLE
feat: Add head function to read first n lines of a file

### DIFF
--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -335,6 +335,12 @@ MAINTENANCE:         Maintained
 STATUS:              Working
 SINCE:               4.0.4
 -------------------------------------------------------------------------------
+EXTENSION:           head
+PRIMARY MAINTAINER:  Jules <jules@dev.null>
+MAINTENANCE:         Maintained
+STATUS:              Working
+SINCE:               8.6.0
+-------------------------------------------------------------------------------
 EXTENSION:           hash
 PRIMARY MAINTAINER:  Sara Golemon <pollita@php.net> (2005 - 2017)
                      Mike Wallner <mike@php.net> (2005 - 2013)

--- a/ext/head/config.m4
+++ b/ext/head/config.m4
@@ -1,0 +1,8 @@
+PHP_ARG_WITH([head],
+  [for head support],
+  [AS_HELP_STRING([--with-head],
+    [Include head support])])
+
+if test "$PHP_HEAD" != "no"; then
+  PHP_NEW_EXTENSION(head, head.c, $ext_shared)
+fi

--- a/ext/head/head.c
+++ b/ext/head/head.c
@@ -1,0 +1,62 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_head.h"
+#include "ext/standard/file.h"
+#include "head_arginfo.h"
+
+PHP_FUNCTION(head)
+{
+    char *filename;
+    size_t filename_len;
+    zend_long lines = 10;
+    FILE *fp;
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t read;
+    zend_long i = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &filename, &filename_len, &lines) == FAILURE) {
+        return;
+    }
+
+    fp = fopen(filename, "r");
+    if (!fp) {
+        php_error_docref(NULL, E_WARNING, "Failed to open file: %s", filename);
+        RETURN_FALSE;
+    }
+
+    array_init(return_value);
+
+    while ((read = getline(&line, &len, fp)) != -1) {
+        if (i >= lines) {
+            break;
+        }
+        add_next_index_stringl(return_value, line, read);
+        i++;
+    }
+
+    fclose(fp);
+    if (line) {
+        free(line);
+    }
+}
+
+zend_module_entry head_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "head",
+    ext_functions,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    "1.0.0",
+    STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_HEAD
+ZEND_GET_MODULE(head)
+#endif

--- a/ext/head/head.stub.php
+++ b/ext/head/head.stub.php
@@ -1,0 +1,5 @@
+<?php
+
+/** @generate-function-entries */
+
+function head(string $filename, int $lines = 10): array|false {}

--- a/ext/head/head_arginfo.h
+++ b/ext/head/head_arginfo.h
@@ -1,0 +1,14 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 311d1049e32af017b44e260a00f13830714b1e96 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_head, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, lines, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_FUNCTION(head);
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(head, arginfo_head)
+	ZEND_FE_END
+};

--- a/ext/head/php_head.h
+++ b/ext/head/php_head.h
@@ -1,0 +1,7 @@
+#ifndef PHP_HEAD_H
+#define PHP_HEAD_H
+
+extern zend_module_entry head_module_entry;
+#define phpext_head_ptr &head_module_entry
+
+#endif

--- a/ext/head/tests/001.phpt
+++ b/ext/head/tests/001.phpt
@@ -1,0 +1,62 @@
+--TEST--
+head() function basic test
+--FILE--
+<?php
+$filename = __DIR__ . '/test.txt';
+file_put_contents($filename, "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12");
+
+var_dump(head($filename));
+var_dump(head($filename, 5));
+
+unlink($filename);
+?>
+--EXPECT--
+array(10) {
+  [0]=>
+  string(6) "line1
+"
+  [1]=>
+  string(6) "line2
+"
+  [2]=>
+  string(6) "line3
+"
+  [3]=>
+  string(6) "line4
+"
+  [4]=>
+  string(6) "line5
+"
+  [5]=>
+  string(6) "line6
+"
+  [6]=>
+  string(6) "line7
+"
+  [7]=>
+  string(6) "line8
+"
+  [8]=>
+  string(6) "line9
+"
+  [9]=>
+  string(7) "line10
+"
+}
+array(5) {
+  [0]=>
+  string(6) "line1
+"
+  [1]=>
+  string(6) "line2
+"
+  [2]=>
+  string(6) "line3
+"
+  [3]=>
+  string(6) "line4
+"
+  [4]=>
+  string(6) "line5
+"
+}


### PR DESCRIPTION
This commit introduces a new PHP extension that provides a `head()` function, which mimics the behavior of the Unix `head` command.

The `head()` function takes a filename and an optional number of lines to read (defaulting to 10) and returns an array of lines from the beginning of the file.

The implementation includes:
- A new `head` extension.
- The C source code for the `head()` function.
- Build configuration files.
- A PHP stub file for static analysis and IDEs.
- A test case to verify the function's behavior.