### PR TITLE
feat(zend): Add TeapotException

### DIFF
--- a/Zend/tests/teapot_exception.phpt
+++ b/Zend/tests/teapot_exception.phpt
@@ -1,0 +1,12 @@
+--TEST--
+TeapotException test
+--FILE--
+<?php
+try {
+    throw new TeapotException("I'm a teapot!");
+} catch (TeapotException $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+I'm a teapot!

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -51,6 +51,7 @@ ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
 ZEND_API zend_class_entry *zend_ce_unhandled_match_error;
 ZEND_API zend_class_entry *zend_ce_request_parse_body_exception;
+ZEND_API zend_class_entry *zend_ce_teapot_exception;
 
 /* Internal pseudo-exception that is not exposed to userland. Throwing this exception *does not* execute finally blocks. */
 static zend_class_entry zend_ce_unwind_exit;
@@ -847,6 +848,9 @@ void zend_register_default_exception(void) /* {{{ */
 
 	zend_ce_request_parse_body_exception = register_class_RequestParseBodyException(zend_ce_exception);
 	zend_init_exception_class_entry(zend_ce_request_parse_body_exception);
+
+	zend_ce_teapot_exception = register_class_TeapotException(zend_ce_exception);
+	zend_init_exception_class_entry(zend_ce_teapot_exception);
 
 	INIT_CLASS_ENTRY(zend_ce_unwind_exit, "UnwindExit", NULL);
 

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -39,6 +39,7 @@ extern ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 extern ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
 extern ZEND_API zend_class_entry *zend_ce_unhandled_match_error;
 extern ZEND_API zend_class_entry *zend_ce_request_parse_body_exception;
+extern ZEND_API zend_class_entry *zend_ce_teapot_exception;
 
 ZEND_API void zend_exception_set_previous(zend_object *exception, zend_object *add_previous);
 ZEND_API void zend_exception_save(void);

--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -174,3 +174,7 @@ class UnhandledMatchError extends Error
 class RequestParseBodyException extends Exception
 {
 }
+
+class TeapotException extends Exception
+{
+}

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ba1562ca8fe2fe48c40bc52d10545aa989afd86c */
+ * Stub hash: 751790f8b73107e4a0cf21c250211eced8fb5064 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -332,6 +332,16 @@ static zend_class_entry *register_class_RequestParseBodyException(zend_class_ent
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "RequestParseBodyException", NULL);
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_TeapotException(zend_class_entry *class_entry_Exception)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "TeapotException", NULL);
 	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Exception, 0);
 
 	return class_entry;


### PR DESCRIPTION
This commit introduces a new TeapotException class to the Zend engine. The exception is defined in `Zend/zend_exceptions.stub.php` and registered in `Zend/zend_exceptions.c`. A new test case is added to verify that the exception can be thrown and caught correctly.