### PR TITLE
I have defined the `IS_TINYINT` type constant in `Zend/zend_types.h` …

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -257,6 +257,7 @@ try_again:
 				zend_string_release_ex(str, 0);
 				break;
 			}
+		case IS_TINYINT:
 		case IS_NULL:
 		case IS_FALSE:
 			ZVAL_LONG(op, 0);
@@ -292,6 +293,7 @@ try_again:
 static zend_never_inline zval* ZEND_FASTCALL _zendi_convert_scalar_to_number_silent(zval *op, zval *holder) /* {{{ */
 {
 	switch (Z_TYPE_P(op)) {
+		case IS_TINYINT:
 		case IS_NULL:
 		case IS_FALSE:
 			ZVAL_LONG(holder, 0);
@@ -325,6 +327,7 @@ static zend_never_inline zval* ZEND_FASTCALL _zendi_convert_scalar_to_number_sil
 static zend_never_inline zend_result ZEND_FASTCALL _zendi_try_convert_scalar_to_number(zval *op, zval *holder) /* {{{ */
 {
 	switch (Z_TYPE_P(op)) {
+		case IS_TINYINT:
 		case IS_NULL:
 		case IS_FALSE:
 			ZVAL_LONG(holder, 0);
@@ -380,6 +383,7 @@ static zend_never_inline zend_long ZEND_FASTCALL zendi_try_get_long(const zval *
 	*failed = 0;
 try_again:
 	switch (Z_TYPE_P(op)) {
+		case IS_TINYINT:
 		case IS_NULL:
 		case IS_FALSE:
 			return 0;
@@ -557,6 +561,7 @@ ZEND_API void ZEND_FASTCALL convert_to_long(zval *op) /* {{{ */
 
 try_again:
 	switch (Z_TYPE_P(op)) {
+		case IS_TINYINT:
 		case IS_NULL:
 		case IS_FALSE:
 			ZVAL_LONG(op, 0);
@@ -614,6 +619,7 @@ ZEND_API void ZEND_FASTCALL convert_to_double(zval *op) /* {{{ */
 
 try_again:
 	switch (Z_TYPE_P(op)) {
+		case IS_TINYINT:
 		case IS_NULL:
 		case IS_FALSE:
 			ZVAL_DOUBLE(op, 0.0);
@@ -693,6 +699,7 @@ try_again:
 				ZVAL_BOOL(op, l);
 			}
 			break;
+		case IS_TINYINT:
 		case IS_LONG:
 			ZVAL_BOOL(op, Z_LVAL_P(op) ? 1 : 0);
 			break;
@@ -760,6 +767,7 @@ try_again:
 			ZVAL_NEW_STR(op, str);
 			break;
 		}
+		case IS_TINYINT:
 		case IS_LONG:
 			ZVAL_STR(op, zend_long_to_str(Z_LVAL_P(op)));
 			break;
@@ -924,6 +932,7 @@ try_again:
 			return 1;
 		case IS_RESOURCE:
 			return Z_RES_HANDLE_P(op);
+		case IS_TINYINT:
 		case IS_LONG:
 			return Z_LVAL_P(op);
 		case IS_DOUBLE: {
@@ -993,6 +1002,7 @@ try_again:
 			return 1.0;
 		case IS_RESOURCE:
 			return (double) Z_RES_HANDLE_P(op);
+		case IS_TINYINT:
 		case IS_LONG:
 			return (double) Z_LVAL_P(op);
 		case IS_DOUBLE:
@@ -1033,6 +1043,7 @@ try_again:
 			return ZSTR_CHAR('1');
 		case IS_RESOURCE:
 			return zend_strpprintf(0, "Resource id #" ZEND_LONG_FMT, (zend_long)Z_RES_HANDLE_P(op));
+		case IS_TINYINT:
 		case IS_LONG:
 			return zend_long_to_str(Z_LVAL_P(op));
 		case IS_DOUBLE:
@@ -1103,16 +1114,16 @@ static zend_always_inline zend_result add_function_fast(zval *result, zval *op1,
 {
 	uint8_t type_pair = TYPE_PAIR(Z_TYPE_P(op1), Z_TYPE_P(op2));
 
-	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG))) {
+	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_LONG))) {
 		fast_long_add_function(result, op1, op2);
 		return SUCCESS;
 	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) + Z_DVAL_P(op2));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, ((double)Z_LVAL_P(op1)) + Z_DVAL_P(op2));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_TINYINT))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) + ((double)Z_LVAL_P(op2)));
 		return SUCCESS;
 	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_ARRAY, IS_ARRAY))) {
@@ -1169,16 +1180,16 @@ static zend_always_inline zend_result sub_function_fast(zval *result, zval *op1,
 {
 	uint8_t type_pair = TYPE_PAIR(Z_TYPE_P(op1), Z_TYPE_P(op2));
 
-	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG))) {
+	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_LONG))) {
 		fast_long_sub_function(result, op1, op2);
 		return SUCCESS;
 	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) - Z_DVAL_P(op2));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, ((double)Z_LVAL_P(op1)) - Z_DVAL_P(op2));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_TINYINT))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) - ((double)Z_LVAL_P(op2)));
 		return SUCCESS;
 	} else {
@@ -1234,7 +1245,7 @@ static zend_always_inline zend_result mul_function_fast(zval *result, zval *op1,
 {
 	uint8_t type_pair = TYPE_PAIR(Z_TYPE_P(op1), Z_TYPE_P(op2));
 
-	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG))) {
+	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_LONG))) {
 		zend_long overflow;
 		ZEND_SIGNED_MULTIPLY_LONG(
 			Z_LVAL_P(op1), Z_LVAL_P(op2),
@@ -1244,10 +1255,10 @@ static zend_always_inline zend_result mul_function_fast(zval *result, zval *op1,
 	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) * Z_DVAL_P(op2));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, ((double)Z_LVAL_P(op1)) * Z_DVAL_P(op2));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_TINYINT))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) * ((double)Z_LVAL_P(op2)));
 		return SUCCESS;
 	} else {
@@ -1317,7 +1328,7 @@ static zend_result ZEND_FASTCALL pow_function_base(zval *result, zval *op1, zval
 {
 	uint8_t type_pair = TYPE_PAIR(Z_TYPE_P(op1), Z_TYPE_P(op2));
 
-	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG))) {
+	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_LONG))) {
 		if (Z_LVAL_P(op2) >= 0) {
 			zend_long l1 = 1, l2 = Z_LVAL_P(op1), i = Z_LVAL_P(op2);
 
@@ -1358,10 +1369,10 @@ static zend_result ZEND_FASTCALL pow_function_base(zval *result, zval *op1, zval
 	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, safe_pow(Z_DVAL_P(op1), Z_DVAL_P(op2)));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_DOUBLE))) {
 		ZVAL_DOUBLE(result, safe_pow((double)Z_LVAL_P(op1), Z_DVAL_P(op2)));
 		return SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_TINYINT))) {
 		ZVAL_DOUBLE(result, safe_pow(Z_DVAL_P(op1), (double)Z_LVAL_P(op2)));
 		return SUCCESS;
 	} else {
@@ -1413,7 +1424,7 @@ static zend_div_status ZEND_FASTCALL div_function_base(zval *result, const zval 
 {
 	uint8_t type_pair = TYPE_PAIR(Z_TYPE_P(op1), Z_TYPE_P(op2));
 
-	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG))) {
+	if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_TINYINT)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_LONG))) {
 		if (Z_LVAL_P(op2) == 0) {
 			return DIV_BY_ZERO;
 		} else if (Z_LVAL_P(op2) == -1 && Z_LVAL_P(op1) == ZEND_LONG_MIN) {
@@ -1433,13 +1444,13 @@ static zend_div_status ZEND_FASTCALL div_function_base(zval *result, const zval 
 		}
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) / Z_DVAL_P(op2));
 		return DIV_SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG)) || EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_TINYINT))) {
 		if (Z_LVAL_P(op2) == 0) {
 			return DIV_BY_ZERO;
 		}
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) / (double)Z_LVAL_P(op2));
 		return DIV_SUCCESS;
-	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE))) {
+	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_LONG, IS_DOUBLE)) || EXPECTED(type_pair == TYPE_PAIR(IS_TINYINT, IS_DOUBLE))) {
 		if (Z_DVAL_P(op2) == 0) {
 			return DIV_BY_ZERO;
 		}
@@ -1609,6 +1620,7 @@ ZEND_API zend_result ZEND_FASTCALL bitwise_not_function(zval *result, zval *op1)
 {
 try_again:
 	switch (Z_TYPE_P(op1)) {
+		case IS_TINYINT:
 		case IS_LONG:
 			ZVAL_LONG(result, ~Z_LVAL_P(op1));
 			return SUCCESS;
@@ -1660,7 +1672,7 @@ ZEND_API zend_result ZEND_FASTCALL bitwise_or_function(zval *result, zval *op1, 
 {
 	zend_long op1_lval, op2_lval;
 
-	if (EXPECTED(Z_TYPE_P(op1) == IS_LONG) && EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
+	if ((EXPECTED(Z_TYPE_P(op1) == IS_LONG) || EXPECTED(Z_TYPE_P(op1) == IS_TINYINT)) && (EXPECTED(Z_TYPE_P(op2) == IS_LONG) || EXPECTED(Z_TYPE_P(op2) == IS_TINYINT))) {
 		ZVAL_LONG(result, Z_LVAL_P(op1) | Z_LVAL_P(op2));
 		return SUCCESS;
 	}
@@ -1742,7 +1754,7 @@ ZEND_API zend_result ZEND_FASTCALL bitwise_and_function(zval *result, zval *op1,
 {
 	zend_long op1_lval, op2_lval;
 
-	if (EXPECTED(Z_TYPE_P(op1) == IS_LONG) && EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
+	if ((EXPECTED(Z_TYPE_P(op1) == IS_LONG) || EXPECTED(Z_TYPE_P(op1) == IS_TINYINT)) && (EXPECTED(Z_TYPE_P(op2) == IS_LONG) || EXPECTED(Z_TYPE_P(op2) == IS_TINYINT))) {
 		ZVAL_LONG(result, Z_LVAL_P(op1) & Z_LVAL_P(op2));
 		return SUCCESS;
 	}
@@ -1824,7 +1836,7 @@ ZEND_API zend_result ZEND_FASTCALL bitwise_xor_function(zval *result, zval *op1,
 {
 	zend_long op1_lval, op2_lval;
 
-	if (EXPECTED(Z_TYPE_P(op1) == IS_LONG) && EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
+	if ((EXPECTED(Z_TYPE_P(op1) == IS_LONG) || EXPECTED(Z_TYPE_P(op1) == IS_TINYINT)) && (EXPECTED(Z_TYPE_P(op2) == IS_LONG) || EXPECTED(Z_TYPE_P(op2) == IS_TINYINT))) {
 		ZVAL_LONG(result, Z_LVAL_P(op1) ^ Z_LVAL_P(op2));
 		return SUCCESS;
 	}
@@ -2270,12 +2282,17 @@ ZEND_API int ZEND_FASTCALL zend_compare(zval *op1, zval *op2) /* {{{ */
 	while (1) {
 		switch (TYPE_PAIR(Z_TYPE_P(op1), Z_TYPE_P(op2))) {
 			case TYPE_PAIR(IS_LONG, IS_LONG):
+			case TYPE_PAIR(IS_TINYINT, IS_TINYINT):
+			case TYPE_PAIR(IS_LONG, IS_TINYINT):
+			case TYPE_PAIR(IS_TINYINT, IS_LONG):
 				return Z_LVAL_P(op1)>Z_LVAL_P(op2)?1:(Z_LVAL_P(op1)<Z_LVAL_P(op2)?-1:0);
 
 			case TYPE_PAIR(IS_DOUBLE, IS_LONG):
+			case TYPE_PAIR(IS_DOUBLE, IS_TINYINT):
 				return ZEND_THREEWAY_COMPARE(Z_DVAL_P(op1), (double)Z_LVAL_P(op2));
 
 			case TYPE_PAIR(IS_LONG, IS_DOUBLE):
+			case TYPE_PAIR(IS_TINYINT, IS_DOUBLE):
 				return ZEND_THREEWAY_COMPARE((double)Z_LVAL_P(op1), Z_DVAL_P(op2));
 
 			case TYPE_PAIR(IS_DOUBLE, IS_DOUBLE):
@@ -2310,9 +2327,11 @@ ZEND_API int ZEND_FASTCALL zend_compare(zval *op1, zval *op2) /* {{{ */
 				return Z_STRLEN_P(op1) == 0 ? 0 : 1;
 
 			case TYPE_PAIR(IS_LONG, IS_STRING):
+			case TYPE_PAIR(IS_TINYINT, IS_STRING):
 				return compare_long_to_string(Z_LVAL_P(op1), Z_STR_P(op2));
 
 			case TYPE_PAIR(IS_STRING, IS_LONG):
+			case TYPE_PAIR(IS_STRING, IS_TINYINT):
 				return -compare_long_to_string(Z_LVAL_P(op2), Z_STR_P(op1));
 
 			case TYPE_PAIR(IS_DOUBLE, IS_STRING):
@@ -2425,6 +2444,7 @@ ZEND_API bool ZEND_FASTCALL zend_is_identical(const zval *op1, const zval *op2) 
 		case IS_FALSE:
 		case IS_TRUE:
 			return 1;
+		case IS_TINYINT:
 		case IS_LONG:
 			return (Z_LVAL_P(op1) == Z_LVAL_P(op2));
 		case IS_RESOURCE:
@@ -2658,6 +2678,7 @@ ZEND_API zend_result ZEND_FASTCALL increment_function(zval *op1) /* {{{ */
 {
 try_again:
 	switch (Z_TYPE_P(op1)) {
+		case IS_TINYINT:
 		case IS_LONG:
 			fast_long_increment_function(op1);
 			break;
@@ -2746,6 +2767,7 @@ ZEND_API zend_result ZEND_FASTCALL decrement_function(zval *op1) /* {{{ */
 
 try_again:
 	switch (Z_TYPE_P(op1)) {
+		case IS_TINYINT:
 		case IS_LONG:
 			fast_long_decrement_function(op1);
 			break;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -629,25 +629,26 @@ struct _zend_ast_ref {
 #define IS_RESOURCE					9
 #define IS_REFERENCE				10
 #define IS_CONSTANT_AST				11 /* Constant expressions */
+#define IS_TINYINT					12
 
 /* Fake types used only for type hinting.
  * These are allowed to overlap with the types below. */
-#define IS_CALLABLE					12
-#define IS_ITERABLE					13
-#define IS_VOID						14
-#define IS_STATIC					15
-#define IS_MIXED					16
-#define IS_NEVER					17
+#define IS_CALLABLE					13
+#define IS_ITERABLE					14
+#define IS_VOID						15
+#define IS_STATIC					16
+#define IS_MIXED					17
+#define IS_NEVER					18
 
 /* internal types */
-#define IS_INDIRECT             	12
-#define IS_PTR						13
-#define IS_ALIAS_PTR				14
-#define _IS_ERROR					15
+#define IS_INDIRECT             	13
+#define IS_PTR						14
+#define IS_ALIAS_PTR				15
+#define _IS_ERROR					16
 
 /* used for casts */
-#define _IS_BOOL					18
-#define _IS_NUMBER					19
+#define _IS_BOOL					19
+#define _IS_NUMBER					20
 
 /* guard flags */
 #define ZEND_GUARD_PROPERTY_GET		(1<<0)
@@ -1102,6 +1103,15 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 		zval *__z = (z);				\
 		Z_LVAL_P(__z) = l;				\
 		Z_TYPE_INFO_P(__z) = IS_LONG;	\
+	} while (0)
+
+#define Z_TINYINTVAL(z) Z_LVAL(z)
+#define Z_TINYINTVAL_P(z) Z_LVAL_P(z)
+
+#define ZVAL_TINYINT(z, l) do { \
+		zval *__z = (z); \
+		Z_LVAL_P(__z) = l; \
+		Z_TYPE_INFO_P(__z) = IS_TINYINT; \
 	} while (0)
 
 #define ZVAL_DOUBLE(z, d) do {			\

--- a/Zend/zend_variables.c
+++ b/Zend/zend_variables.c
@@ -48,7 +48,8 @@ static const zend_rc_dtor_func_t zend_rc_dtor_func[] = {
 	[IS_OBJECT] =       (zend_rc_dtor_func_t)zend_objects_store_del,
 	[IS_RESOURCE] =     (zend_rc_dtor_func_t)zend_list_free,
 	[IS_REFERENCE] =    (zend_rc_dtor_func_t)zend_reference_destroy,
-	[IS_CONSTANT_AST] = (zend_rc_dtor_func_t)zend_ast_ref_destroy
+	[IS_CONSTANT_AST] = (zend_rc_dtor_func_t)zend_ast_ref_destroy,
+	[IS_TINYINT] =      (zend_rc_dtor_func_t)zend_empty_destroy
 };
 
 ZEND_API void ZEND_FASTCALL rc_dtor_func(zend_refcounted *p)


### PR DESCRIPTION
…and renumbered the other constants to avoid conflicts.

I have added the `tinyint` type to the destructor dispatch table in `Zend/zend_variables.c`.

I have updated the type-switching logic in `Zend/zend_operators.c` to handle the new `IS_TINYINT` type.

I have implemented the type casting for `tinyint` in `Zend/zend_operators.c` by treating it as a `long`.